### PR TITLE
Make `GetProbableGenotypes` aware of multiallelic genotypes

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -16,6 +16,11 @@ scripts into polyRAD.
 A Python script has been added to help identify full tag sequences for alleles
 imported from TASSEL-GBSv2 using VCF2RADdata.
 
+The GetProbableGenotypes function has been updated to optionally recognize
+genotypes where copy number does not sum to the ploidy across all alleles for a
+locus.  It can now either set these genotypes to NA or correct them to sum to
+the ploidy.  Some internal Rcpp functions were added for this purpose.
+
 A bug has been fixed in SubsetByPloidy.
 
 MergeTaxaDepth now generates a more useful error if taxa are specified that

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -9,6 +9,10 @@ BestGenos <- function(probs, ploidy, ntaxa, nalleles) {
     .Call('_polyRAD_BestGenos', PACKAGE = 'polyRAD', probs, ploidy, ntaxa, nalleles)
 }
 
+CorrectGenos <- function(bestgenos, probs, alleles2loc, ntaxa, ploidy, nalleles, nloc, do_correct) {
+    .Call('_polyRAD_CorrectGenos', PACKAGE = 'polyRAD', bestgenos, probs, alleles2loc, ntaxa, ploidy, nalleles, nloc, do_correct)
+}
+
 BestPloidies <- function(chisq) {
     .Call('_polyRAD_BestPloidies', PACKAGE = 'polyRAD', chisq)
 }

--- a/man/GetWeightedMeanGenotypes.Rd
+++ b/man/GetWeightedMeanGenotypes.Rd
@@ -31,7 +31,8 @@ GetProbableGenotypes(object, ...)
 \method{GetProbableGenotypes}{RADdata}(object, omit1allelePerLocus = TRUE,
                      omitCommonAllele = TRUE,
                      naIfZeroReads = FALSE, 
-                     correctParentalGenos = TRUE, \dots)
+                     correctParentalGenos = TRUE,
+                     multiallelic = "correct", \dots)
 }
 \arguments{
   \item{object}{
@@ -89,6 +90,15 @@ are corrected according to the progeny allele frequencies, using the
 \code{likelyGeno_donor} and \code{likelyGeno_recurrent} slots in \code{object}.
 For the ploidy of the marker, the appropriate ploidy for the parents is 
 selected using the \code{donorPloidies} and \code{recurrentPloidies} slots.
+}
+\item{multiallelic}{
+A string indicating how to handle cases where allele copy number across all
+alleles at a locus does not sum to the ploidy.  To retain the most probable
+copy number for each allele, even if they don't sum to the ploidy across
+all alleles, use \code{"ignore"}.  To be conservative and convert these allele
+copy numbers to \code{NA}, use \code{"na"}.  To adjust allele copy numbers to
+match the ploidy (maximizing the product of posterior probabilities across
+alleles, within the space of possible multiallelic genotypes), use \code{"correct"}.
 }
 }
 

--- a/src/BestGenos.cpp
+++ b/src/BestGenos.cpp
@@ -68,13 +68,15 @@ List BestMultiGeno(NumericVector probs, int ploidy, int nalleles, int choose) {
     // if only one allele remains, all remaining copies must be this allele
     outgeno[0] = choose;
     bestprob = probs[RCto1D(p1, choose, 0)];
-  } else if(choose == 0){
+  }
+  if(nalleles > 1 && choose == 0){
     // if none could be chosen, get the prob of zero for everything
     bestprob = 1;
     for(int a = 0; a < nalleles; a++){
       bestprob *= probs[RCto1D(p1, 0, a)];
     }
-  } else {
+  }
+  if(nalleles > 1 && choose > 0){
     // remove first allele from probabilities
     probssub = probs[Range(RCto1D(p1, 0, 1),
                            RCto1D(p1, ploidy, nalleles - 1))];

--- a/src/BestGenos.cpp
+++ b/src/BestGenos.cpp
@@ -84,7 +84,7 @@ List BestMultiGeno(NumericVector probs, int ploidy, int nalleles, int choose) {
     // loop through possible copy numbers for first allele
     for(int i = 0; i < choose + 1; i++){
       thisprob = probs[RCto1D(p1, i, 0)];
-      subres = BestMultiGeno(probssub, ploidy, choose - i, nalleles - 1);
+      subres = BestMultiGeno(probssub, ploidy, nalleles - 1, choose - i);
       subres_bestprob = subres["bestprob"];
       thisprob *= subres_bestprob;
       if(thisprob > bestprob){

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -32,6 +32,24 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// CorrectGenos
+IntegerMatrix CorrectGenos(IntegerMatrix bestgenos, NumericVector probs, IntegerVector alleles2loc, int ntaxa, int ploidy, int nalleles, int nloc, bool do_correct);
+RcppExport SEXP _polyRAD_CorrectGenos(SEXP bestgenosSEXP, SEXP probsSEXP, SEXP alleles2locSEXP, SEXP ntaxaSEXP, SEXP ploidySEXP, SEXP nallelesSEXP, SEXP nlocSEXP, SEXP do_correctSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< IntegerMatrix >::type bestgenos(bestgenosSEXP);
+    Rcpp::traits::input_parameter< NumericVector >::type probs(probsSEXP);
+    Rcpp::traits::input_parameter< IntegerVector >::type alleles2loc(alleles2locSEXP);
+    Rcpp::traits::input_parameter< int >::type ntaxa(ntaxaSEXP);
+    Rcpp::traits::input_parameter< int >::type ploidy(ploidySEXP);
+    Rcpp::traits::input_parameter< int >::type nalleles(nallelesSEXP);
+    Rcpp::traits::input_parameter< int >::type nloc(nlocSEXP);
+    Rcpp::traits::input_parameter< bool >::type do_correct(do_correctSEXP);
+    rcpp_result_gen = Rcpp::wrap(CorrectGenos(bestgenos, probs, alleles2loc, ntaxa, ploidy, nalleles, nloc, do_correct));
+    return rcpp_result_gen;
+END_RCPP
+}
 // BestPloidies
 IntegerVector BestPloidies(NumericMatrix chisq);
 RcppExport SEXP _polyRAD_BestPloidies(SEXP chisqSEXP) {
@@ -126,6 +144,7 @@ END_RCPP
 static const R_CallMethodDef CallEntries[] = {
     {"_polyRAD_AdjustAlleleFreq", (DL_FUNC) &_polyRAD_AdjustAlleleFreq, 3},
     {"_polyRAD_BestGenos", (DL_FUNC) &_polyRAD_BestGenos, 4},
+    {"_polyRAD_CorrectGenos", (DL_FUNC) &_polyRAD_CorrectGenos, 8},
     {"_polyRAD_BestPloidies", (DL_FUNC) &_polyRAD_BestPloidies, 1},
     {"_polyRAD_GiniSimpson", (DL_FUNC) &_polyRAD_GiniSimpson, 1},
     {"_polyRAD_HindHeMat", (DL_FUNC) &_polyRAD_HindHeMat, 5},


### PR DESCRIPTION
Add the ability to correct multiallelic genotypes to ensure that the sum of copy numbers across all alleles for a given locus is always equal to the ploidy.  The internal `BestMultiGeno` function recursively searches all possible (i.e. totaling to the ploidy) multiallelic genotypes to find the one that has the highest product of posterior probabilities across alleles, for one taxon*locus.  The internal `CorrectGenos` function takes an allele copy number matrix such as that output by `GetProbableGenotypes`, finds genotypes where allele copy does not sum to the ploidy, and depending on the `do_correct` argument either sets these to `NA` or runs `BestMultiGeno` to correct them.  `GetProbableGenotypes` now internally calls `CorrectGenos` unless the user sets `multiallelic = "ignore"`.