### PR TITLE
Updates to haplotype merging

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: polyRAD
-Version: 1.6.0.9002
-Date: 2022-08-28
+Version: 1.6.0.9003
+Date: 2022-09-25
 Title: Genotype Calling with Uncertainty from Sequencing Data in Polyploids and Diploids
 Authors@R: c(person("Lindsay V.", "Clark", email = "Lindsay.Clark@seattlechildrens.org",
                     role = c("aut", "cre"), 

--- a/NEWS.md
+++ b/NEWS.md
@@ -26,7 +26,9 @@ used.
 * The `readDArTag` function has been updated to support a newer format from
 Excellence in Breeding, as well as their original format.
 
-* `MergeIdenticalHaplotypes` now takes IUPAC ambiguity codes into account.
+* `MergeIdenticalHaplotypes` now takes IUPAC ambiguity codes into account. It is
+now used internally by `VCF2RADdata`, `readStacks`, `readTASSELGBSv2`, and
+`readProcessIsoloci`.
 
 # polyRAD 1.6
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -26,6 +26,8 @@ used.
 * The `readDArTag` function has been updated to support a newer format from
 Excellence in Breeding, as well as their original format.
 
+* `MergeIdenticalHaplotypes` now takes IUPAC ambiguity codes into account.
+
 # polyRAD 1.6
 
 * `TestOverdispersion` now prints a helpful suggestion for which overdispersion

--- a/R/calculations.R
+++ b/R/calculations.R
@@ -247,6 +247,40 @@ polyRADsubmat <- matrix(c(0,1,1,1, 0,0,0,1,1,1, 0,0,0,1, 0,1,1, # A
                                            'S', 'Y', 'K', 'V', 'H', 'D', 'B', 
                                            'N', '-', '.')))
 
+# get distance (number of mutations) between two sets of nucleotide strings
+.nucdist <- function(alleles1, alleles2 = NULL){
+  nsites <- unique(nchar(c(alleles1, alleles2)))
+  stopifnot(length(nsites) == 1)
+  splitnuc1 <- strsplit(alleles1, split = "")
+  
+  if(is.null(alleles2)){ # square matrix for all combinations of alleles
+    nal <- length(alleles1)
+    out <- matrix(0L, nrow = nal, ncol = nal, dimnames = list(alleles1, alleles1))
+    for(a1 in 1:(nal - 1)){
+      for(a2 in (a1 + 1):nal){
+        out[a1,a2] <- out[a2,a1] <-
+          sum(sapply(seq_len(nsites),
+                     function(i) polyRADsubmat[splitnuc1[[a1]][i],
+                                               splitnuc1[[a2]][i]]))
+      }
+    }
+  } else { # all comparisons between sets of alleles
+    out <- matrix(0L, nrow = length(alleles1), ncol = length(alleles2),
+                  dimnames = list(alleles1, alleles2))
+    splitnuc2 <- strsplit(alleles2, split = "")
+    for(a1 in seq_along(alleles1)){
+      for(a2 in seq_along(alleles2)){
+        if(alleles1[a1] == alleles2[a2]) next
+        out[a1,a2] <-
+          sum(sapply(seq_len(nsites),
+                     function(i) polyRADsubmat[splitnuc1[[a1]][i],
+                                               splitnuc2[[a2]][i]]))
+      }
+    }
+  }
+  return(out)
+}
+
 # Reverse complement; set up as S4 method to be compatible with Biostrings
 setGeneric("reverseComplement", signature="x",
            function(x, ...) standardGeneric("reverseComplement")

--- a/R/classes_methods.R
+++ b/R/classes_methods.R
@@ -2380,6 +2380,7 @@ MergeIdenticalHaplotypes.RADdata <- function(object, ...){
   if(!is.null(object$alleleFreq) || !is.null(object$depthSamplingPermutations)){
     stop("Run MergeIdenticalHaplotypes before running any pipeline functions.")
   }
+  varsiteonly <- attr(object$alleleNucleotides, "Variable_sites_only")
   
   remal <- integer(0) # indices of alleles to remove
   for(L in 1:nLoci(object)){
@@ -2404,13 +2405,14 @@ MergeIdenticalHaplotypes.RADdata <- function(object, ...){
   }
   
   # remove duplicated alleles from all slots
-  object$alleleDepth <- object$alleleDepth[,-remal]
-  object$antiAlleleDepth <- object$antiAlleleDepth[,-remal]
-  object$alleles2loc <- object$alleles2loc[-remal]
-  varsiteonly <- attr(object$alleleNucleotides, "Variable_sites_only")
-  object$alleleNucleotides <- object$alleleNucleotides[-remal]
+  if(length(remal) > 0){
+    object$alleleDepth <- object$alleleDepth[,-remal]
+    object$antiAlleleDepth <- object$antiAlleleDepth[,-remal]
+    object$alleles2loc <- object$alleles2loc[-remal]
+    object$alleleNucleotides <- object$alleleNucleotides[-remal]
+    object$depthRatio <- object$depthRatio[,-remal]
+  }
   attr(object$alleleNucleotides, "Variable_sites_only") <- varsiteonly
-  object$depthRatio <- object$depthRatio[,-remal]
   
   return(object)
 }

--- a/R/classes_methods.R
+++ b/R/classes_methods.R
@@ -2009,15 +2009,8 @@ MergeRareHaplotypes.RADdata <- function(object, min.ind.with.haplotype = 10,
     while(length(theserare) > 0 && length(thesealleles) > 1){
       thisAl <- theserare[1]
       # get nucleotide distance between this allele and others
-      thesenuc <- object$alleleNucleotides[thesealleles]
-      splitnuc <- strsplit(thesenuc, split = "")
-      splitnucA <- splitnuc[[which(thesealleles == thisAl)]]
-      nucdist <- integer(length(thesealleles))
-      for(a in 1:length(thesealleles)){
-        nucdist[a] <- sum(sapply(1:length(splitnucA),
-                                 function(i) polyRADsubmat[splitnucA[i],
-                                                           splitnuc[[a]][i]]))
-      }
+      nucdist <- .nucdist(object$alleleNucleotides[thisAl],
+                          object$alleleNucleotides[thesealleles])
       # find the closest allele
       alToMerge <- thesealleles[nucdist == min(nucdist[-match(thisAl, thesealleles)])]
       if(length(alToMerge) > 1){

--- a/R/data_import.R
+++ b/R/data_import.R
@@ -926,6 +926,7 @@ VCF2RADdata <- function(file, phaseSNPs = TRUE, tagsize = 80, refgenome = NULL,
   message("Merging rare haplotypes...")
   radout <- MergeRareHaplotypes(radout, 
                                 min.ind.with.haplotype = min.ind.with.minor.allele)
+  radout <- MergeIdenticalHaplotypes(radout)
   radout <- RemoveMonomorphicLoci(radout)
   
   # indicate whether non-variable sites included in alleleNucleotides
@@ -1102,6 +1103,7 @@ readStacks <- function(allelesFile, matchesFolder, version = 2,
   message("Merging rare haplotypes...")
   radout <- MergeRareHaplotypes(radout, 
                                 min.ind.with.haplotype = min.ind.with.minor.allele)
+  radout <- MergeIdenticalHaplotypes(radout)
   radout <- RemoveMonomorphicLoci(radout)
   return(radout)
 }
@@ -1252,6 +1254,7 @@ readTASSELGBSv2 <- function(tagtaxadistFile, samFile, min.ind.with.reads = 200,
                     contamRate, samseq, taxaPloidy)
   radout <- MergeRareHaplotypes(radout, 
                                 min.ind.with.haplotype = min.ind.with.minor.allele)
+  radout <- MergeIdenticalHaplotypes(radout)
   radout <- RemoveMonomorphicLoci(radout)
   attr(radout$alleleNucleotides, "Variable_sites_only") <- FALSE
   return(radout)
@@ -1496,6 +1499,7 @@ readProcessIsoloci <- function(sortedfile, min.ind.with.reads = 200,
   if(mergeRareHap){
     radout <- MergeRareHaplotypes(radout, 
                                   min.ind.with.haplotype = min.ind.with.minor.allele)
+    radout <- MergeIdenticalHaplotypes(radout)
     radout <- RemoveMonomorphicLoci(radout)
   }
   return(radout)

--- a/man/MergeIdenticalHaplotypes.Rd
+++ b/man/MergeIdenticalHaplotypes.Rd
@@ -5,7 +5,8 @@
 Merge Alleles with Identical DNA Sequences
 }
 \description{
-If any alleles within a locus have identical \code{alleleNucleotides} values,
+If any alleles within a locus have identical \code{alleleNucleotides} values
+(including those identical based on IUPAC ambiguity codes),
 this function merges those alleles, summing their read depths.  This function is
 primarily intended to be used internally in cases where tags vary in length
 within a locus, resulting in truncated \code{alleleNucleotides}.
@@ -38,7 +39,7 @@ Lindsay V. Clark
 \examples{
 data(exampleRAD)
 # change a haplotype for this example
-exampleRAD$alleleNucleotides[5] <- "GC"
+exampleRAD$alleleNucleotides[5] <- "GY"
 
 nAlleles(exampleRAD)
 exampleRAD <- MergeIdenticalHaplotypes(exampleRAD)

--- a/man/MergeRareHaplotypes.Rd
+++ b/man/MergeRareHaplotypes.Rd
@@ -57,9 +57,9 @@ Lindsay V. Clark
 \examples{
 data(exampleRAD)
 exampleRAD2 <- MergeRareHaplotypes(exampleRAD, 
-                                   min.ind.with.haplotype = 12)
-exampleRAD$alleleDepth[21:30,3:5]
-exampleRAD2$alleleDepth[21:30,3:4]
+                                   min.ind.with.haplotype = 20)
+exampleRAD$alleleDepth[21:30,6:7]
+exampleRAD2$alleleDepth[21:30,6,drop=FALSE]
 exampleRAD$alleleNucleotides
 exampleRAD2$alleleNucleotides
 }


### PR DESCRIPTION
In working on incorporating sequencing error into the estimation of genotype likelihoods, I made some fixes and changes that went into the `main` branch because they will be useful even if sequencing error is not ultimately incorporated.  This pull request merges them back to the `seqerror` branch so I can continue working on it.

* The internal function `.nucdist` was added, using code from `MergeRareHaplotypes`. This function calculates the number of mutations between haplotypes, and will be used by `MergeRareHaplotypes`, `MergeIdenticalHaplotypes`, and `AddErrorMatrices`.
* `MergeIdenticalHaplotypes` was changed so that it not only merges alleles with completely identical `alleleNucleotides`, but also alleles that have zero distance between them based on IUPAC ambiguity codes (_i.e._ `.nucdist` returns zero).  Several import functions now run `MergeIdenticalHaplotypes` immediately after running `MergeRareHaplotypes`.  This issue came up in the testing of `AddErrorMatrices` on the _Miscanthus sacchariflorus_ dataset, when alleles "YTTTW" and "TTTTA" were both present in one locus generated by `VCF2RADdata`.