### PR TITLE
Speedy geno correct

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: polyRAD
-Version: 1.6.0.9003
-Date: 2022-09-25
+Version: 1.6.0.9004
+Date: 2022-10-01
 Title: Genotype Calling with Uncertainty from Sequencing Data in Polyploids and Diploids
 Authors@R: c(person("Lindsay V.", "Clark", email = "Lindsay.Clark@seattlechildrens.org",
                     role = c("aut", "cre"), 

--- a/NEWS.md
+++ b/NEWS.md
@@ -28,7 +28,12 @@ Excellence in Breeding, as well as their original format.
 
 * `MergeIdenticalHaplotypes` now takes IUPAC ambiguity codes into account. It is
 now used internally by `VCF2RADdata`, `readStacks`, `readTASSELGBSv2`, and
-`readProcessIsoloci`.
+`readProcessIsoloci`. Some additional loci will now be filtered out by these
+functions.
+
+* `GetProbableGenotypes` with `multiallelic = "correct"`, and by extension
+`RADdata2VCF`, now run much faster by searching a much narrower range of
+possible multiallelic genotypes.
 
 # polyRAD 1.6
 

--- a/man/ExportGAPIT.Rd
+++ b/man/ExportGAPIT.Rd
@@ -356,7 +356,7 @@ outfile4 <- tempfile() # temporary file for example
 Export_Structure(exampleRAD, outfile4)
 
 # export to adegenet
-if(requireNamespace("adegenet", quiet = TRUE)){
+if(requireNamespace("adegenet", quietly = TRUE)){
   mygenind <- Export_adegenet_genind(exampleRAD)
 }
 }

--- a/man/GetWeightedMeanGenotypes.Rd
+++ b/man/GetWeightedMeanGenotypes.Rd
@@ -97,8 +97,8 @@ alleles at a locus does not sum to the ploidy.  To retain the most probable
 copy number for each allele, even if they don't sum to the ploidy across
 all alleles, use \code{"ignore"}.  To be conservative and convert these allele
 copy numbers to \code{NA}, use \code{"na"}.  To adjust allele copy numbers to
-match the ploidy (maximizing the product of posterior probabilities across
-alleles, within the space of possible multiallelic genotypes), use \code{"correct"}.
+match the ploidy (adding or subtracting allele copies while maximizing the
+product of posterior probabilities across alleles), use \code{"correct"}.
 }
 }
 

--- a/src/BestGenos.cpp
+++ b/src/BestGenos.cpp
@@ -182,6 +182,7 @@ IntegerMatrix CorrectGenos(IntegerMatrix bestgenos, NumericVector probs,
   IntegerVector thisgeno;
   int thisnal;
   bool genoOK;
+  bool genoNA;
   NumericVector theseprobs;
   int p1 = ploidy + 1;
   
@@ -195,14 +196,14 @@ IntegerMatrix CorrectGenos(IntegerMatrix bestgenos, NumericVector probs,
         thisgeno[a] = bestgenos(t, thesecol[a]);
       }
       genoOK = sum(thisgeno) == ploidy;
-      if(is_true(any(is_na(thisgeno))) || 
-         (!do_correct && !genoOK)){
+      genoNA = is_true(any(is_na(thisgeno)));
+      if(genoNA || (!do_correct && !genoOK)){
         // fill in missing data for this genotype
         for(int a = 0; a < thisnal; a++){
           bestgenos(t, thesecol[a]) = NA_INTEGER;
         }
       }
-      if(do_correct && !genoOK){
+      if(do_correct && !genoOK && !genoNA){
         // get posterior probabilities at this taxon and locus
         for(int c = 0; c < p1; c++){
           for(int a = 0; a < thisnal; a++){

--- a/src/BestGenos.cpp
+++ b/src/BestGenos.cpp
@@ -105,7 +105,6 @@ List BestMultiGeno(NumericVector probs, int ploidy, int nalleles, int choose) {
 
 // Function to correct a genotype that just needs one more allele. Designed to
 // explore a much smaller region of the search space than BestMultiGeno.
-// [[Rcpp::export]]
 IntegerVector AddOneAllele(IntegerVector geno, NumericVector probs, int ploidy,
                            int nalleles) {
   IntegerVector outgeno(nalleles);
@@ -114,7 +113,6 @@ IntegerVector AddOneAllele(IntegerVector geno, NumericVector probs, int ploidy,
   int p1 = ploidy + 1;
   IntegerVector thisgeno(nalleles);
   
-  // Get it working then make into while look to keep adding alleles up to ploidy
   // Loop through alleles to potentially add
   for(int a1 = 0; a1 < nalleles; a1++){
     thisprob = 1;
@@ -179,8 +177,13 @@ IntegerMatrix CorrectGenos(IntegerMatrix bestgenos, NumericVector probs,
           }
         }
         // find the most probable multiallelic genotype
-        newgeno = BestMultiGeno(theseprobs, ploidy, thisnal, ploidy);
-        thisgeno = newgeno["outgeno"];
+        while(sum(thisgeno) < ploidy){
+          thisgeno = AddOneAllele(thisgeno, theseprobs, ploidy, thisnal);
+        }
+        if(sum(thisgeno) > ploidy){
+          newgeno = BestMultiGeno(theseprobs, ploidy, thisnal, ploidy);
+          thisgeno = newgeno["outgeno"];
+        }
         // fill in new genotypes
         for(int a = 0; a < thisnal; a++){
           bestgenos(t, thesecol[a]) = thisgeno[a];

--- a/src/BestGenos.cpp
+++ b/src/BestGenos.cpp
@@ -103,6 +103,40 @@ List BestMultiGeno(NumericVector probs, int ploidy, int nalleles, int choose) {
   return out;
 }
 
+// Function to correct a genotype that just needs one more allele. Designed to
+// explore a much smaller region of the search space than BestMultiGeno.
+// [[Rcpp::export]]
+IntegerVector AddOneAllele(IntegerVector geno, NumericVector probs, int ploidy,
+                           int nalleles) {
+  IntegerVector outgeno(nalleles);
+  double bestprob = 0;
+  double thisprob;
+  int p1 = ploidy + 1;
+  IntegerVector thisgeno(nalleles);
+  
+  // Get it working then make into while look to keep adding alleles up to ploidy
+  // Loop through alleles to potentially add
+  for(int a1 = 0; a1 < nalleles; a1++){
+    thisprob = 1;
+    // Loop to calculate probability and build genotype
+    for(int a2 = 0; a2 < nalleles; a2++){
+      if(a1 == a2){
+        thisprob *= probs[RCto1D(p1, geno[a2] + 1, a2)];
+        thisgeno[a2] = geno[a2] + 1;
+      } else {
+        thisprob *= probs[RCto1D(p1, geno[a2], a2)];
+        thisgeno[a2] = geno[a2];
+      }
+    }
+    if(thisprob > bestprob){
+      bestprob = thisprob;
+      std::copy( thisgeno.begin(), thisgeno.end(), outgeno.begin() ) ;
+    }
+  }
+  
+  return outgeno;
+}
+
 // Function to determine if multi-allelic genotypes are consistent with ploidy
 // after calling under a pseudo-biallelic model.  Can set inconsistent
 // genotypes either to missing or correct them.


### PR DESCRIPTION
`GetProbableGenotypes` was very slow with `multallelic = "correct"`, causing for example `RADdata2VCF` to take an inordinate amount of processing time.  This fix speeds it up about 1000X by reducing the search space of multiallelic genotypes that are tested.  Instead of testing all possible genotypes, the pseudobiallelic genotype is assumed to be mostly correct, and then alleles are added or subtracted as needed to sum to the ploidy.